### PR TITLE
Nick mods

### DIFF
--- a/pyccl/halos/concentration.py
+++ b/pyccl/halos/concentration.py
@@ -391,9 +391,9 @@ def concentration_from_name(name):
     Returns:
         Concentration subclass corresponding to the input name.
     """
-    concentrations = {c.name: c
+    concentrations = {c.name.lower(): c
                       for c in Concentration.__subclasses__()}
-    if name in concentrations:
+    if name.lower() in concentrations:
         return concentrations[name]
     else:
         raise ValueError("Concentration %s not implemented")

--- a/pyccl/halos/halos_extra.py
+++ b/pyccl/halos/halos_extra.py
@@ -203,7 +203,7 @@ class HaloProfileArnaud(HaloProfile):
         h70 = cosmo["h"]/0.7
         P0 = 6.41  # reference pressure
 
-        K = 1.65*h70**2*P0 * (h70/3e14)**(2/3+aP)  # prefactor
+        K = 1.65*h70*P0 * (h70/3e14)**(2/3+aP)  # prefactor
 
         PM = (M*(1-b))**(2/3+aP)             # mass dependence
         Pz = h_over_h0(cosmo, a)**(8/3)  # scale factor (z) dependence

--- a/pyccl/halos/hbias.py
+++ b/pyccl/halos/hbias.py
@@ -358,8 +358,8 @@ def halo_bias_from_name(name):
     Returns:
         HaloBias subclass corresponding to the input name.
     """
-    bias_functions = {c.name: c for c in HaloBias.__subclasses__()}
-    if name in bias_functions:
+    bias_functions = {c.name.lower(): c for c in HaloBias.__subclasses__()}
+    if name.lower() in bias_functions:
         return bias_functions[name]
     else:
         raise ValueError("Halo bias parametrization %s not implemented")

--- a/pyccl/halos/hmfunc.py
+++ b/pyccl/halos/hmfunc.py
@@ -741,8 +741,8 @@ def mass_function_from_name(name):
     Returns:
         MassFunc subclass corresponding to the input name.
     """
-    mass_functions = {c.name: c for c in MassFunc.__subclasses__()}
-    if name in mass_functions:
+    mass_functions = {c.name.lower(): c for c in MassFunc.__subclasses__()}
+    if name.lower() in mass_functions:
         return mass_functions[name]
     else:
         raise ValueError("Mass function %s not implemented")


### PR DESCRIPTION
- corrected h70 factor in HOD
- 'tinker08' etc. would complain unless first letter was capitalized. Message would be 'tinker08' not implemented, possibly misleading user into thinking the Tinker08 mass function had not been implemented. Fixed this in all mfunc, hbias, concentration.
